### PR TITLE
Instantiate turn and take in a guess

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "flashcards-starter",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/src/Card.js
+++ b/src/Card.js
@@ -5,16 +5,6 @@ class Card {
     this.answers = answers
     this.correctAnswer = correctAnswer
   }
-    guess(guess) {
-      console.log('false')
-      if (!guess === this.correctAnswer) {
-        console.log('false')
-        return false
-      } else {
-        console.log('true')
-        return true
-      }
-    }
 }
 
 

--- a/src/Turn.js
+++ b/src/Turn.js
@@ -1,0 +1,15 @@
+class Turn {
+  constructor(guess, card) {
+    this.guess = guess
+    this.card = card
+  }
+  returnGuess() {
+    return this.guess
+    }
+    returnCard() {
+      console.log(this.card)
+      return this.card
+    }
+}
+
+module.exports = Turn;

--- a/test/Card-test.js
+++ b/test/Card-test.js
@@ -2,6 +2,7 @@ const chai = require('chai');
 const expect = chai.expect;
 
 const Card = require('../src/Card');
+// const Turn = require('../src/Turn.js');
 
 describe('Card', function() {
 
@@ -30,11 +31,6 @@ describe('Card', function() {
     expect(card.correctAnswer).to.equal('object');
   });
 
-  it('should return a guess', function() {
-    const card = new Card(1, 'What is 1 + 1', [['2', '3', '22'], '2']);
-    const guess = card.guess
-    card.guess('2')
-    expect(card.guess).to.equal('2')
+  
 
-  })
 });

--- a/test/Turn-test.js
+++ b/test/Turn-test.js
@@ -1,0 +1,31 @@
+const chai = require('chai');
+const expect = chai.expect;
+
+const Turn = require('../src/Turn');
+const Card = require('../src/Card');
+
+describe('Turn', function() {
+  let card;
+  let turn;
+  beforeEach(() => {
+      card = new Card(1, 'What is 1 + 1 ?', ['2', '3', '4'], '2');
+      turn = new Turn('2', card);
+    });
+
+  it('should be a function', function() {
+    expect(Turn).to.be.a('function');
+  });
+
+  it('should be an instance of Turn', function() {
+    expect(turn).to.be.an.instanceof(Turn);
+  });
+
+  it('should return a guess', () => {
+    expect(turn.returnGuess()).to.equal('2');
+  });
+
+  it('should return a card', () => {
+    const turn = new Turn();
+    expect(turn.returnCard()).to.equal(turn.card);
+  })
+})


### PR DESCRIPTION
Change: Added functionality to the Turn class.
Fixed: We can now instantiate an instance of Turn and return a card.
This is a new feature and it does not break any existing functionality.
Tested: in the terminal using npm test, Mocha and Chai.